### PR TITLE
refactor!: throw errors instead of returning them

### DIFF
--- a/index.js
+++ b/index.js
@@ -171,7 +171,6 @@
 			.catch( error_ => {
 
 				error = error_
-				return error_
 
 			} )
 
@@ -179,6 +178,13 @@
 		if ( cb ) {
 
 			return cb( error, response )
+
+		}
+
+		// Non-callback, throw errors
+		if ( error ) {
+
+			throw error
 
 		}
 

--- a/test.js
+++ b/test.js
@@ -35,8 +35,15 @@ test( 'handles invalid query', async t => {
 
 	t.plan( 1 )
 
-	const response = await albumArt( 'zyxwvutsrq' )
-	t.is( response instanceof Error, true, 'response is an error' )
+	try {
+
+		await albumArt( 'zyxwvutsrq' )
+
+	} catch ( e ) {
+
+		t.is( e instanceof Error, true, 'response is an error' )
+
+	}
 
 } )
 


### PR DESCRIPTION
Per #13, this `throw`s Errors so callers can catch different kinds of errors and respond accordingly.

(Note, if you're planning to release another major version...The code could be greatly simplified by removing support for callbacks. Let me know if you're interested in that and I'd be happy to submit another PR.)

Closes #13 