### PR TITLE
fix: special characters in album option incorrectly throwing 400 errors

### DIFF
--- a/index.js
+++ b/index.js
@@ -65,7 +65,7 @@
 
 		// Create request URL
 		const method = ( opts.album === null ) ? 'artist' : 'album'
-		const queryParams = `?q=${encodeURIComponent( artist )}${method === 'album' ? '%20' + opts.album : ''}&type=${method}&limit=1`
+		const queryParams = `?q=${encodeURIComponent( artist )}${method === 'album' ? '%20' + encodeURIComponent( opts.album ) : ''}&type=${method}&limit=1`
 		const searchUrl = `${apiEndpoint}/search${queryParams}`
 		const authString = `${clientId}:${clientSecret}`
 

--- a/test.js
+++ b/test.js
@@ -75,3 +75,12 @@ test( 'callback returns a url', async t => {
 
 } )
 
+test( 'can handle special characters in album name', async t => {
+
+	t.plan( 1 )
+
+	const response = await albumArt( 'kaytranada', {album: '99.9%'} )
+	t.is( response.indexOf( 'http' ), 0, 'response is a URL' )
+
+} )
+


### PR DESCRIPTION
## Expected Behavior

Using a special character in the `album` option should work. E.G. [Kaytranada's "99.9%" album](https://www.discogs.com/master/1000756-Kaytranada-999).

## Observed Behavior

The request fails.

```
> album-art 'Kaytranada' --album 99.9%
FetchError: invalid json response body at https://api.spotify.com/v1/search?q=Kaytranada%2099.9%&type=album&limit=1 reason: Unexpected end of JSON input
    at /path/to/album-art/node_modules/node-fetch/lib/body.js:48:31
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    at async albumArt (/path/to/album-art/index.js:112:30)
```

## Proposed Fix

Correctly encode special characters in the album name.