### PR TITLE
ci: upgrade github/codeql-action v3 → v4 (Node.js 24)

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -23,18 +23,18 @@ jobs:
         language: ['javascript-typescript']
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3
+        uses: github/codeql-action/init@v4
         with:
           languages: ${{ matrix.language }}
           queries: security-and-quality
 
       - name: Autobuild
-        uses: github/codeql-action/autobuild@v3
+        uses: github/codeql-action/autobuild@v4
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v3
+        uses: github/codeql-action/analyze@v4
         with:
           category: "/language:${{ matrix.language }}"


### PR DESCRIPTION
## Summary

GitHub Actions will force Node.js 24 by default starting **June 2nd, 2026**. This upgrades CodeQL to the Node.js 24-compatible `v4`.

Changes:
- `github/codeql-action/init@v3` → `@v4`
- `github/codeql-action/autobuild@v3` → `@v4`
- `github/codeql-action/analyze@v3` → `@v4`
- `actions/checkout@v4` → `@v6` (album-art only)

## Test plan

- [ ] CodeQL workflow passes after merge