### PR TITLE
chore: fix package.json repository field

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,10 @@
   "name": "album-art",
   "version": "4.0.3",
   "description": "Fetch the cover art for an artist or album: The Beatles ➔ http://path/to/beatles.jpg",
-  "repository": "lacymorrow/album-art",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/lacymorrow/album-art.git"
+  },
   "license": "MIT",
   "author": {
     "name": "Lacy Morrow",


### PR DESCRIPTION
## Summary
- Normalize `repository` field in package.json per npm publish standards
- Convert string shorthand to object format with `type` and `url`
- Normalize URLs to `git+https://` format

Automated fix via `npm pkg fix`. Addresses npm publish warnings.